### PR TITLE
Fix small memory leak

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -81,6 +81,7 @@ std::string GetSanitizedNameOfCurrentApplication() {
         result.clear();
     }
     ACPFinalize();
+    free(metaXml);
     return result;
 }
 


### PR DESCRIPTION
Frees the allocated `ACPMetaXml` after getting the title's name