### PR TITLE
Fix unable to compile with DEBUG flag

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -198,7 +198,7 @@ void InitConfig() {
 
 void multipleValueItemCallback(ConfigItemMultipleValues *item, uint32_t newValue) {
     if (item && item->identifier) {
-        DEBUG_FUNCTION_LINE("New value in %s changed: %d", item->configId, newValue);
+        DEBUG_FUNCTION_LINE("New value in %s changed: %d", item->identifier, newValue);
         if (std::string_view(item->identifier) == FORMAT_CONFIG_STRING) {
             gOutputFormat = (ImageOutputFormatEnum) newValue;
 
@@ -227,7 +227,7 @@ void multipleValueItemCallback(ConfigItemMultipleValues *item, uint32_t newValue
 
 void integerRangeItemCallback(ConfigItemIntegerRange *item, int32_t newValue) {
     if (item && item->identifier) {
-        DEBUG_FUNCTION_LINE("New value in %s changed: %d", item->configId, newValue);
+        DEBUG_FUNCTION_LINE("New value in %s changed: %d", item->identifier, newValue);
         if (std::string_view(item->identifier) == QUALITY_CONFIG_STRING) {
             gQuality = (ImageOutputFormatEnum) newValue;
 
@@ -247,7 +247,7 @@ void integerRangeItemCallback(ConfigItemIntegerRange *item, int32_t newValue) {
 
 void boolItemCallback(ConfigItemBoolean *item, bool newValue) {
     if (item && item->identifier) {
-        DEBUG_FUNCTION_LINE("New value in %s changed: %d", item->configId, newValue);
+        DEBUG_FUNCTION_LINE("New value in %s changed: %d", item->identifier, newValue);
         if (std::string_view(item->identifier) == ENABLED_CONFIG_STRING) {
             gEnabled = newValue;
             if (gEnabled) {
@@ -270,7 +270,7 @@ void boolItemCallback(ConfigItemBoolean *item, bool newValue) {
 
 void buttonComboItemChanged(ConfigItemButtonCombo *item, uint32_t newValue) {
     if (item && item->identifier) {
-        DEBUG_FUNCTION_LINE("New value in %s changed: %08X", item->configId, newValue);
+        DEBUG_FUNCTION_LINE("New value in %s changed: %08X", item->identifier, newValue);
         if (std::string_view(item->identifier) == BUTTON_COMBO_CONFIG_STRING) {
             gButtonCombo = newValue;
             WUPSStorageError err;

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -43,6 +43,7 @@ extern "C" {
 
 #define DEBUG_FUNCTION_LINE_ERR(FMT, ARGS...)                                  LOG_EX_DEFAULT(WHBLogPrintf, "##ERROR## ", "", FMT, ##ARGS)
 #define DEBUG_FUNCTION_LINE_WARN(FMT, ARGS...)                                 LOG_EX_DEFAULT(WHBLogPrintf, "##WARN ## ", "", FMT, ##ARGS)
+#define DEBUG_FUNCTION_LINE_INFO(FMT, ARGS...)                                 LOG_EX_DEFAULT(WHBLogPrintf, "##INFO ## ", "", FMT, ##ARGS)
 
 #define DEBUG_FUNCTION_LINE_ERR_LAMBDA(FILENAME, FUNCTION, LINE, FMT, ARGS...) LOG_EX(FILENAME, FUNCTION, LINE, WHBLogPrintf, "##ERROR## ", "", FMT, ##ARGS);
 


### PR DESCRIPTION
Changed configId to identifier to reflect previous change in the plugin system.
Inserted missing DEBUG_FUNCTION_LINE_INFO macro.